### PR TITLE
Homologate from 485b48b to 509ca05

### DIFF
--- a/src/lib/core/run.js
+++ b/src/lib/core/run.js
@@ -83,7 +83,7 @@ function resolve(obj, data, values, property) {
 }
 
 // TODO provide types?
-function run(refs, schema, container, synchronous) {
+function run(refs, schema, container, synchronous, validateSchema) {
   if (Object.prototype.toString.call(schema) !== '[object Object]') {
     throw new Error(`Invalid input, expecting object but given ${typeof schema}`);
   }
@@ -100,7 +100,7 @@ function run(refs, schema, container, synchronous) {
       refDepthMin,
       refDepthMax,
     });
-    const result = traverse(utils.clone(schema), [], resolveSchema);
+    const result = traverse(utils.clone(schema), [], resolveSchema, undefined, validateSchema);
 
     if (optionAPI('resolveJsonPath')) {
       return {

--- a/src/lib/core/traverse.js
+++ b/src/lib/core/traverse.js
@@ -15,7 +15,7 @@ function getMeta({ $comment: comment, title, description }) {
 }
 
 // TODO provide types
-function traverse(schema, path, resolve, rootSchema) {
+function traverse(schema, path, resolve, rootSchema, validateSchema) {
   schema = resolve(schema, null, path);
 
   if (schema && (schema.oneOf || schema.anyOf || schema.allOf)) {
@@ -36,14 +36,43 @@ function traverse(schema, path, resolve, rootSchema) {
     // example values have highest precedence
     if (optionAPI('useExamplesValue') && Array.isArray(schema.examples)) {
       // include `default` value as example too
-      const fixedExamples = schema.examples
-        .concat('default' in schema ? [schema.default] : []);
-
-      return { value: utils.typecast(null, schema, () => random.pick(fixedExamples)), context };
+      const fixedExamples = schema.examples.concat(
+        'default' in schema ? [schema.default] : []);
+      const randomExample = random.pick(fixedExamples);
+      if (validateSchema) {
+        const result = validateSchema(schema, randomExample);
+        console.log(result);
+        // Use example only if valid
+        if (result && result.length === 0) {
+          return {
+            value: utils.typecast(null, schema, () => randomExample),
+            context,
+          };
+        }
+      } else {
+        console.warn('Taking example from schema without validation');
+        return {
+          value: utils.typecast(null, schema, () => randomExample),
+          context,
+        };
+      }
     }
     // If schema contains single example property
     if (optionAPI('useExamplesValue') && schema.example) {
-      return { value: utils.typecast(null, schema, () => schema.example), context };
+      if (validateSchema) {
+        const result = validateSchema(schema, schema.example);
+
+        // Use example only if valid
+        if (result && result.length === 0) {
+          return {
+            value: utils.typecast(null, schema, () => schema.example),
+            context,
+          };
+        }
+      } else {
+        console.warn('Taking example from schema without validation');
+        return { value: utils.typecast(null, schema, () => schema.example), context };
+      }
     }
 
     if (optionAPI('useDefaultValue') && 'default' in schema) {
@@ -66,7 +95,7 @@ function traverse(schema, path, resolve, rootSchema) {
 
     // build new object value from not-schema!
     if (schema.type && schema.type === 'object') {
-      const { value, context: innerContext } = traverse(schema, path.concat(['not']), resolve, rootSchema);
+      const { value, context: innerContext } = traverse(schema, path.concat(['not']), resolve, rootSchema, validateSchema);
       return { value: utils.clean(value, schema, false), context: { ...context, items: innerContext } };
     }
   }
@@ -74,7 +103,7 @@ function traverse(schema, path, resolve, rootSchema) {
   // thunks can return sub-schemas
   if (typeof schema.thunk === 'function') {
     // result is already cleaned in thunk
-    const { value, context: innerContext } = traverse(schema.thunk(rootSchema), path, resolve);
+    const { value, context: innerContext } = traverse(schema.thunk(rootSchema), path, resolve, undefined, validateSchema);
     return { value, context: { ...context, items: innerContext } };
   }
 
@@ -172,7 +201,7 @@ function traverse(schema, path, resolve, rootSchema) {
   Object.keys(schema).forEach(prop => {
     if (pruneProperties.includes(prop)) return;
     if (typeof schema[prop] === 'object' && prop !== 'definitions') {
-      const { value, context: innerContext } = traverse(schema[prop], path.concat([prop]), resolve, valueCopy);
+      const { value, context: innerContext } = traverse(schema[prop], path.concat([prop]), resolve, valueCopy, validateSchema);
       valueCopy[prop] = utils.clean(value, schema[prop], false);
       contextCopy[prop] = innerContext;
     } else {

--- a/src/lib/core/traverse.js
+++ b/src/lib/core/traverse.js
@@ -41,7 +41,6 @@ function traverse(schema, path, resolve, rootSchema, validateSchema) {
       const randomExample = random.pick(fixedExamples);
       if (validateSchema) {
         const result = validateSchema(schema, randomExample);
-        console.log(result);
         // Use example only if valid
         if (result && result.length === 0) {
           return {

--- a/src/lib/generators/coreFormat.js
+++ b/src/lib/generators/coreFormat.js
@@ -1,5 +1,10 @@
 import random from '../core/random';
 
+/**
+ * Added few formats from latest json-schema-faker. see below for source
+ * https://github.com/json-schema-faker/json-schema-faker/blob/master/src/lib/generators/coreFormat.js
+ *
+ */
 const FRAGMENT = '[a-zA-Z][a-zA-Z0-9+-.]*';
 const URI_PATTERN = `https?://{hostname}(?:${FRAGMENT})+`;
 const PARAM_PATTERN = '(?:\\?([a-z]{1,7}(=\\w{1,5})?&){0,3})?';

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -93,18 +93,18 @@ const jsf = (schema, refs, cwd) => {
   return jsf.generate(schema, refs);
 };
 
-jsf.generateWithContext = (schema, refs) => {
+jsf.generateWithContext = (schema, refs, validateSchema) => {
   const $refs = getRefs(refs, schema);
 
-  return run($refs, schema, container, true);
+  return run($refs, schema, container, true, validateSchema);
 };
 
-jsf.generate = (schema, refs) => renderJS(
-    jsf.generateWithContext(schema, refs),
+jsf.generate = (schema, refs, validateSchema) => renderJS(
+    jsf.generateWithContext(schema, refs, validateSchema),
   );
 
-jsf.generateYAML = (schema, refs) => renderYAML(
-    jsf.generateWithContext(schema, refs),
+jsf.generateYAML = (schema, refs, validateSchema) => renderYAML(
+    jsf.generateWithContext(schema, refs, validateSchema),
   );
 
 jsf.resolveWithContext = (schema, refs, cwd) => {

--- a/src/lib/types/array.js
+++ b/src/lib/types/array.js
@@ -24,7 +24,7 @@ function unique(path, items, value, sample, resolve, traverseCallback) {
   items.forEach(walk);
 
   // TODO: find a better solution?
-  let limit = 100;
+  let limit = 10;
 
   while (tmp.length !== items.length) {
     if (!walk(traverseCallback(value.items || sample, path, resolve))) {

--- a/tests/unit/core/index.spec.js
+++ b/tests/unit/core/index.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import jsf from '../../../src/lib';
 
-describe('jsf', () => {
+describe('jsf generate', () => {
   it('Take example without validation', () => {
     const schema = {
       type: 'integer',
@@ -20,12 +20,38 @@ describe('jsf', () => {
     jsf.option('useExamplesValue', true);
     expect(jsf.generate(schema, undefined, () => { return []; })).to.eql(123);
   });
-
   it('Generate fake data when example is not valid', () => {
     const schema = {
       type: 'integer',
       format: 'int32',
       example: '123',
+    };
+    jsf.option('useExamplesValue', true);
+    expect(jsf.generate(schema, undefined, () => { return [{ error: 'some' }]; })).to.be.an('number');
+  });
+  it('Take one example from examples without validation', () => {
+    const schema = {
+      type: 'integer',
+      format: 'int32',
+      examples: [123, 456],
+    };
+    jsf.option('useExamplesValue', true);
+    expect([123, 456]).to.include(jsf.generate(schema));
+  });
+  it('Take one example from examples with validation', () => {
+    const schema = {
+      type: 'integer',
+      format: 'int32',
+      examples: [123, 456],
+    };
+    jsf.option('useExamplesValue', true);
+    expect([123, 456]).to.include(jsf.generate(schema, undefined, () => { return []; }));
+  });
+  it('Generate fake data when example from examples is not valid', () => {
+    const schema = {
+      type: 'integer',
+      format: 'int32',
+      examples: ['123', '456'],
     };
     jsf.option('useExamplesValue', true);
     expect(jsf.generate(schema, undefined, () => { return [{ error: 'some' }]; })).to.be.an('number');

--- a/tests/unit/core/index.spec.js
+++ b/tests/unit/core/index.spec.js
@@ -28,7 +28,7 @@ describe('jsf', () => {
       example: '123',
     };
     jsf.option('useExamplesValue', true);
-    expect(jsf.generate(schema, undefined, () => { console.log('here'); return [{ error: 'some' }]; })).to.be.an('number');
+    expect(jsf.generate(schema, undefined, () => { return [{ error: 'some' }]; })).to.be.an('number');
   });
 });
 

--- a/tests/unit/core/index.spec.js
+++ b/tests/unit/core/index.spec.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import jsf from '../../../src/lib';
+
+describe('jsf', () => {
+  it('Take example without validation', () => {
+    const schema = {
+      type: 'integer',
+      format: 'int32',
+      example: 123,
+    };
+    jsf.option('useExamplesValue', true);
+    expect(jsf.generate(schema)).to.eql(123);
+  });
+  it('Take example with validation', () => {
+    const schema = {
+      type: 'integer',
+      format: 'int32',
+      example: 123,
+    };
+    jsf.option('useExamplesValue', true);
+    expect(jsf.generate(schema, undefined, () => { return []; })).to.eql(123);
+  });
+
+  it('Generate fake data when example is not valid', () => {
+    const schema = {
+      type: 'integer',
+      format: 'int32',
+      example: '123',
+    };
+    jsf.option('useExamplesValue', true);
+    expect(jsf.generate(schema, undefined, () => { console.log('here'); return [{ error: 'some' }]; })).to.be.an('number');
+  });
+});
+


### PR DESCRIPTION
Homologate the commits from OAtoP


485b48b changed json-schema-faker behaviour to not throw an error for circular refs
c04835e resolving circular refs by shallow cloning schema in case of array in deref.js
1bd4c2b using example values instead of faking schema
2c42272 Added support for suggesting available fixes
fb079ae Use faked value as example if schema example is invalid *
8b2e366 Added source for new supported formats from latest json schema faker
509ca05 Update size limit for highest complexity, jsf limit update in unique function

Add unit tests for example scenarios